### PR TITLE
Fix pokemon timestampMs

### DIFF
--- a/src/services/consumer.js
+++ b/src/services/consumer.js
@@ -576,7 +576,7 @@ class Consumer {
                                 wild: encounter.wild_pokemon,
                                 username: this.username,
                                 cellId: cellId,
-                                timestampMs: encounter.wild_pokemon.last_modified_timestamp_ms //last_modified_timestamp_ms / timestamp_ms
+                                timestampMs: parseInt(BigInt(encounter.wild_pokemon.last_modified_timestamp_ms).toString()) //last_modified_timestamp_ms / timestamp_ms
                             });
                             await pokemon.addEncounter(encounter, this.username);
                         //}


### PR DESCRIPTION
Sometimes when updating the encounter the following error occured:

[Encounter] Error: ER_WARN_DATA_OUT_OF_RANGE: Out of range value for column 'expire_timestamp' at row 1